### PR TITLE
Chore/bcs 1749/sns bulk publisher

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/aws/aws-sdk-go v1.43.24 h1:7c2PniJ0wpmWsIA6OtYBw6wS7DF0IjbhvPq+0ZQYNX
 github.com/aws/aws-sdk-go v1.43.24/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=

--- a/publisher/sns/mock_test.go
+++ b/publisher/sns/mock_test.go
@@ -15,3 +15,10 @@ func (p *snsPublisherMock) PublishWithContext(ctx context.Context, input *sns.Pu
 	p.queue <- input.Message
 	return &sns.PublishOutput{}, nil
 }
+
+func (p *snsPublisherMock) PublishBatchWithContext(ctx context.Context, input *sns.PublishBatchInput, o ...request.Option) (*sns.PublishBatchOutput, error) {
+	for _, entry := range input.PublishBatchRequestEntries {
+		p.queue <- entry.Message
+	}
+	return &sns.PublishBatchOutput{}, nil
+}

--- a/publisher/sns/sns.go
+++ b/publisher/sns/sns.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sns"
+	"github.com/google/uuid"
 )
 
 // sender is the interface to sns.SNS. Its sole purpose is to make
@@ -94,7 +95,9 @@ func (p *Publisher) PublishBatch(ctx context.Context, msgs []interface{}) error 
 				return err
 			}
 
+			entryId := uuid.New().String()
 			requestEntry := &sns.PublishBatchRequestEntry{
+				Id:      aws.String(entryId),
 				Message: aws.String(string(b)),
 			}
 


### PR DESCRIPTION
### What is this change about?
- Add support for batch publishing of messages to SNS topics



### Relevant Documentation
- https://github.com/aws/aws-sdk-go/blob/v1.44.8/service/sns/api.go#L3385

### Other Relevant PRs


### Screenshots
