### PR TITLE
Chore/bcs 1862/error handling batch publish

### DIFF
--- a/constants/errors.go
+++ b/constants/errors.go
@@ -1,0 +1,9 @@
+package constants
+
+const (
+	GenericError = "GenericError"
+)
+
+var ErrorStrings = map[string]string{
+	GenericError: "publish error",
+}

--- a/constants/errors.go
+++ b/constants/errors.go
@@ -1,9 +1,9 @@
 package constants
 
 const (
-	GenericError = "GenericError"
+	GenericPublishError = "GenericPublishError"
 )
 
 var ErrorStrings = map[string]string{
-	GenericError: "publish error",
+	GenericPublishError: "publish error",
 }

--- a/constants/publisher.go
+++ b/constants/publisher.go
@@ -1,0 +1,5 @@
+package constants
+
+const (
+	MaxBatchSize = 10 // 10 is the maximum batch size for SNS.PublishBatch
+)

--- a/publisher/models/message.go
+++ b/publisher/models/message.go
@@ -1,0 +1,6 @@
+package models
+
+type Message struct {
+	ID   string      `json:"id"`
+	Data interface{} `json:"data"`
+}

--- a/publisher/sns/sns.go
+++ b/publisher/sns/sns.go
@@ -77,15 +77,14 @@ func (p *Publisher) PublishBatch(ctx context.Context, msgs []models.Message) (ma
 
 		errorCount   int64
 		successCount int64
-	)
 
-	isFifo := strings.Contains(strings.ToLower(p.cfg.TopicArn), "fifo")
-
-	var (
 		numPublishedMessages = 0
 		start                = 0
 		end                  = constants.MaxBatchSize
 	)
+
+	isFifo := strings.Contains(strings.ToLower(p.cfg.TopicArn), "fifo")
+
 	if end > len(msgs) {
 		end = len(msgs)
 	}

--- a/publisher/sns/sns.go
+++ b/publisher/sns/sns.go
@@ -124,7 +124,7 @@ func (p *Publisher) PublishBatch(ctx context.Context, msgs []models.Message) (ma
 
 		for _, errEntry := range response.Failed {
 			if errEntry != nil && errEntry.Id != nil {
-				errMsg := "publish error"
+				errMsg := constants.GenericPublishError
 				if errEntry.Message != nil {
 					errMsg = *errEntry.Message
 				}


### PR DESCRIPTION
### What is this change about?
- Since individual messages can error out during a batch publish, the response has to be parsed and each entry in this response has to be checked for an error. This change checks that and returns the message id and error for that message, if present. In addition to this, the `PublishBatch` method has also been modified to return the total number of success and errors that occurred when publishing messages in the batch (for easy logging).



### Relevant Documentation
> Add links to the documentation that describes this change in the code. 
> In case there are no docs, please write a short description of the solution here




### Other Relevant PRs
> Add links to other relevant PRs in this section & also mention the sequence of reviews that should be followed




### Screenshots
> Add screenshots here, especially if this is a frontend change
> Prefer animated gif here
